### PR TITLE
split a long label into a label + doc

### DIFF
--- a/pipeline.cwl
+++ b/pipeline.cwl
@@ -45,7 +45,8 @@ outputs:
   filtered_data:
     outputSource: scanpy_analysis/filtered_data
     type: File
-    label: >-
+    label: Full data set of filtered results
+    doc: >-
       Full data set of filtered results: expression matrix, coordinates in
       dimensionality-reduced space (PCA and UMAP), cluster assignments via
       the Leiden algorithm, and marker genes for one cluster vs. rest


### PR DESCRIPTION
Makes for a better visualization of the workflow

Before: https://w3id.org/cwl/view/git/278890c1f502467a04f94e9c38f43cf1464e5cf5/pipeline.cwl

![current workflow visualization](https://view.commonwl.org/graph/png/github.com/hubmapconsortium/salmon-rnaseq/blob/278890c1f502467a04f94e9c38f43cf1464e5cf5/pipeline.cwl)

After: https://w3id.org/cwl/view/git/3f4d0ec7a4703371885c7ce7e24d95fb25febeeb/pipeline.cwl

![revised workflow visualization](https://view.commonwl.org/graph/png/github.com/mr-c/salmon-rnaseq/blob/3f4d0ec7a4703371885c7ce7e24d95fb25febeeb/pipeline.cwl)

Some of the other `label`s could turn into a `label` + `doc`, but that's is for someone with more expertise than me to decide